### PR TITLE
Exception handling for db.insert in bulkInsert.

### DIFF
--- a/S09.02-Solution-ContentProviderBulkInsert/app/src/main/java/com/example/android/sunshine/data/WeatherProvider.java
+++ b/S09.02-Solution-ContentProviderBulkInsert/app/src/main/java/com/example/android/sunshine/data/WeatherProvider.java
@@ -160,6 +160,8 @@ public class WeatherProvider extends ContentProvider {
                         long _id = db.insert(WeatherContract.WeatherEntry.TABLE_NAME, null, value);
                         if (_id != -1) {
                             rowsInserted++;
+                        } else {
+                            throw new SQLException("Failed to insert item: " + value + " into uri: " + uri);
                         }
                     }
                     db.setTransactionSuccessful();


### PR DESCRIPTION
If we throw an Exception when the date is not normalized I think we should handle the case where db.insert fails with the same severity.

Currently it would mark the transaction as complete, meaning that if some items fails to be inserted, and are then read from the database, our recycler view will show the stored items and our user will see we are missing data.