### PR TITLE
Remove un-needed attributes

### DIFF
--- a/S06.02-Solution-SettingsFragment/app/src/main/res/xml/pref_general.xml
+++ b/S06.02-Solution-SettingsFragment/app/src/main/res/xml/pref_general.xml
@@ -16,9 +16,7 @@
 -->
 <!--COMPLETED (2) Create an xml resource directory-->
 <!--COMPLETED (3) Add a PreferenceScreen with an EditTextPreference and ListPreference within the newly created xml resource directory-->
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-                  android:layout_width="match_parent"
-                  android:layout_height="match_parent">
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
     <EditTextPreference
         android:defaultValue="@string/pref_location_default"


### PR DESCRIPTION
There is no use of using these atrributes, check this [discussion](https://discussions.udacity.com/t/how-can-preferencescreen-contain-android-layout-width-and-android-layout-height/477080/8) 