### PR TITLE
(02.02 solution) Fix to attribute android:appShowAsAction not found

### DIFF
--- a/S02.02-Solution-Menus/app/src/main/res/menu/forecast.xml
+++ b/S02.02-Solution-Menus/app/src/main/res/menu/forecast.xml
@@ -25,6 +25,5 @@
     <item
         android:id="@+id/action_refresh"
         android:orderInCategory="1"
-        android:title="@string/action_refresh"
-        app:showAsAction="ifRoom"/>
+        android:title="@string/action_refresh" />
 </menu>


### PR DESCRIPTION
<img width="1262" alt="Screenshot 2019-07-08 15 41 24" src="https://user-images.githubusercontent.com/11345614/60847641-410d4380-a198-11e9-92ec-6721331fca48.png">
